### PR TITLE
menu.cfg: added memtest option as a submenu with run variants

### DIFF
--- a/debian-installer/i386/boot-screens/menu.cfg
+++ b/debian-installer/i386/boot-screens/menu.cfg
@@ -24,27 +24,27 @@ menu exit
 menu label Back to main menu
 
 label V4.3 (Default)
-	menulabel V4.3 (^Default)
+	menu label V4.3 (^Default)
 	kernel memtest86+pro/isolinux/memtest
 	append console=ttyS0,115200 earlyprint=serial,ttyS0,115200
 
-label V4.3 (^One Pass enabled)
-	menulabel V4.3 (One Pass enabled)
+label V4.3 (One Pass enabled)
+	menu label V4.3 (^One Pass enabled)
 	kernel memtest86+pro/isolinux/memtest
 	append onepass console=ttyS0,115200 earlyprint=serial,ttyS0,115200
 
 label V4.3 (Boot Trace Enabled)
-	menulabel V4.3 (^Boot Trace Enabled)
+	menu label V4.3 (^Boot Trace Enabled)
 	kernel memtest86+pro/isolinux/memtest
 	append btrace console=ttyS0,115200 earlyprint=serial,ttyS0,115200
 
 label V4.3 (Start only one CPU)
-	menulabel V4.3 (^Start only one CPU)
+	menu label V4.3 (^Start only one CPU)
 	kernel memtest86+pro/isolinux/memtest
 	append maxcpus=1 console=ttyS0,115200 earlyprint=serial,ttyS0,115200
 
 label V4.3 (Serial console enabled)
-	menulabel V4.3 (Serial ^console enabled)
+	menu label V4.3 (Serial ^console enabled)
 	kernel memtest86+pro/isolinux/memtest
 	append console=ttyS0,115200 earlyprint=serial,ttyS0,115200
 

--- a/debian-installer/i386/boot-screens/menu.cfg
+++ b/debian-installer/i386/boot-screens/menu.cfg
@@ -3,7 +3,7 @@ menu width 61
 
 menu title PXE server boot menu
 label install
-	menu label ^Install
+	menu label ^Install debian
 	kernel debian-installer/i386/linux
 	append initrd=debian-installer/i386/initrd.gz --- console=ttyS0,115200 earlyprint=serial,ttyS0,115200
 label debian
@@ -14,3 +14,38 @@ label voyage
 	menu label ^Voyage-netinst
 	kernel voyage/vmlinuz
 	append initrd=voyage/initrd.img boot=live netboot=nfs root=/dev/nfs rw ip=dhcp nfsroot=192.168.0.109:/srv/nfs/voyage --- console=ttyS0,115200 earlyprint=serial,ttyS0,115200
+
+menu begin Memtest86+ pro
+menu label ^Memtest86+ pro
+MENU TITLE PXE server boot menu
+
+label Back to main menu
+menu exit
+menu label Back to main menu
+
+label V4.3 (Default)
+	menulabel V4.3 (^Default)
+	kernel memtest86+pro/isolinux/memtest
+	append console=ttyS0,115200 earlyprint=serial,ttyS0,115200
+
+label V4.3 (^One Pass enabled)
+	menulabel V4.3 (One Pass enabled)
+	kernel memtest86+pro/isolinux/memtest
+	append onepass console=ttyS0,115200 earlyprint=serial,ttyS0,115200
+
+label V4.3 (Boot Trace Enabled)
+	menulabel V4.3 (^Boot Trace Enabled)
+	kernel memtest86+pro/isolinux/memtest
+	append btrace console=ttyS0,115200 earlyprint=serial,ttyS0,115200
+
+label V4.3 (Start only one CPU)
+	menulabel V4.3 (^Start only one CPU)
+	kernel memtest86+pro/isolinux/memtest
+	append maxcpus=1 console=ttyS0,115200 earlyprint=serial,ttyS0,115200
+
+label V4.3 (Serial console enabled)
+	menulabel V4.3 (Serial ^console enabled)
+	kernel memtest86+pro/isolinux/memtest
+	append console=ttyS0,115200 earlyprint=serial,ttyS0,115200
+
+MENU END


### PR DESCRIPTION
@pietrushnic 
After booting to `pxelinux.0` PXE boot menu pops up with and additional submenu option `Memtest86+ pro`. User can choose from 5 available run options of Memtest86+ pro or go back to main menu.