### PR TITLE
preseed.cfg: fix partman preseed configuration

### DIFF
--- a/preseed.cfg.sata
+++ b/preseed.cfg.sata
@@ -18,18 +18,19 @@ d-i mirror/http/proxy string
 d-i clock-setup/utc boolean true
 d-i clock-setup/ntp boolean true
 d-i time/zone string Europe/Warsaw
-d-i partman/mount_style select uuid
-d-i partman/confirm boolean true
-d-i partman/choose_partition select finish
-d-i partman/confirm_nooverwrite boolean true
+
 d-i partman-auto/disk string /dev/disk/by-path/pci-0000:00:11.0-ata-1
 d-i partman-auto/method string regular
-d-i partman-auto/choose_recipe select atomic
 d-i partman-lvm/device_remove_lvm boolean true
+d-i partman-md/device_remove_md boolean true
 d-i partman-lvm/confirm boolean true
 d-i partman-lvm/confirm_nooverwrite boolean true
-d-i partman-auto-lvm/guided_size string max
+d-i partman-auto/choose_recipe select atomic
 d-i partman-partitioning/confirm_write_new_label boolean true
+d-i partman/choose_partition select finish
+d-i partman/confirm boolean true
+d-i partman/confirm_nooverwrite boolean true
+d-i partman/mount_style select uuid
 
 d-i grub-installer/grub2_instead_of_grub_legacy boolean true
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=666974

--- a/preseed.cfg.usb
+++ b/preseed.cfg.usb
@@ -18,18 +18,19 @@ d-i mirror/http/proxy string
 d-i clock-setup/utc boolean true
 d-i clock-setup/ntp boolean true
 d-i time/zone string Europe/Warsaw
-d-i partman/mount_style select uuid
-d-i partman/confirm boolean true
-d-i partman/choose_partition select finish
-d-i partman/confirm_nooverwrite boolean true
+
 d-i partman-auto/disk string /dev/disk/by-path/pci-0000:00:10.0-usb-0:1:1.0-scsi-0:0:0:0
 d-i partman-auto/method string regular
-d-i partman-auto/choose_recipe select atomic
 d-i partman-lvm/device_remove_lvm boolean true
+d-i partman-md/device_remove_md boolean true
 d-i partman-lvm/confirm boolean true
 d-i partman-lvm/confirm_nooverwrite boolean true
-d-i partman-auto-lvm/guided_size string max
+d-i partman-auto/choose_recipe select atomic
 d-i partman-partitioning/confirm_write_new_label boolean true
+d-i partman/choose_partition select finish
+d-i partman/confirm boolean true
+d-i partman/confirm_nooverwrite boolean true
+d-i partman/mount_style select uuid
 
 d-i grub-installer/grub2_instead_of_grub_legacy boolean true
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=666974


### PR DESCRIPTION
Debian installation has been failing on apu4 and apu6 whenever
the installation process entered partman phase. When partman was
launched, it immediately seg faulted which resulted in kernel panic
in some cases. The process always failed, but when tested manually
without passing the preseed file, everything worked as expected.
With these preseeds the seg faults do not happen. Partman options
based on https://www.debian.org/releases/buster/example-preseed.txt

Signed-off-by: Michał Żygowski <michal.zygowski@3mdeb.com>